### PR TITLE
Adding remove at price menu option

### DIFF
--- a/src/main/java/org/asundr/OfferAtPriceConfig.java
+++ b/src/main/java/org/asundr/OfferAtPriceConfig.java
@@ -96,6 +96,12 @@ public interface OfferAtPriceConfig extends Config
 	default boolean notifyNotEnough() { return true; }
 
 	@ConfigItem(
+			keyName = "notifyNeedToAdd", name = "Notify if need to add", description = "Send notification trying to remove offered items but already haven't offered enough to match the other offer at the entered price",
+			section = SECTION_NOTIFICATIONS
+	)
+	default boolean notifyNeedToAdd() { return true; }
+
+	@ConfigItem(
 			keyName = "hideOverlayForInvalid", name = "Hide overlay if invalid", description = "Hide overlay if not a 'simple trade' of currency for a single item type",
 			section = SECTION_OVERLAY_PRICE, position = -9
 	)

--- a/src/main/java/org/asundr/OfferManager.java
+++ b/src/main/java/org/asundr/OfferManager.java
@@ -27,8 +27,8 @@ public class OfferManager
 {
     private static final class TradeMenuId
     {
-        public static final int TRADE_MENU = 335;
-        public static final int TRADE_CONFIRMATION_MENU = 334;
+        public static final int TRADE_MENU = InterfaceID.TRADEMAIN;
+        public static final int TRADE_CONFIRMATION_MENU = InterfaceID.TRADECONFIRM;
     }
     private static final class TradeContainerId
     {
@@ -70,7 +70,9 @@ public class OfferManager
     private static final String OPTION_EXAMINE = "Examine";
     private static final String OPTION_SET_PRICE = "Set price";
     private static final String TEXT_OFFER_X = "Offer-X";
+    private static final String TEXT_REMOVE_X = "Remove-X";
     private static final String TEXT_OFFER_PRICE_X = "Offer-Price-X";
+    private static final String TEXT_REMOVE_PRICE_X = "Remove-Price-X";
     private static final String TEXT_INITIAL_PROMPT_FOR_PRICE = "Enter a price:";
 
     private static Client client;
@@ -105,7 +107,7 @@ public class OfferManager
         this.priceKeyListener = new PriceKeyListener(client, clientThread, config);
         keyManager.registerKeyListener(this.priceKeyListener);
         eventBus.register(this.priceKeyListener);
-        this.priceKeyListener.setOnSubmitted(() -> this.priceKeyListener.setActive(false));
+        this.priceKeyListener.setOnSubmitted(() -> this.priceKeyListener.setTransferState(PriceKeyListener.TransferState.INACTIVE));
 
         overlayPricePerItem = new OverlayPricePerItem(config, clientThread, itemManager);
         overlayPriceDifference = new OverlayPriceDifference(config);
@@ -167,7 +169,7 @@ public class OfferManager
         }
         else if (event.getGroupId() == WIDGET_ID_TEXT_ENTRY)
         {
-            priceKeyListener.setActive(false);
+            priceKeyListener.setTransferState(PriceKeyListener.TransferState.INACTIVE);
         }
     }
 
@@ -211,14 +213,16 @@ public class OfferManager
             {
                 return;
             }
+            final String option = Text.removeTags(entry.getOption()).trim();
             switch (WidgetUtil.componentToInterface(w.getId()))
             {
                 case InterfaceID.TRADESIDE:
+                {
                     if (!client.isKeyPressed(KeyCode.KC_SHIFT))
                     {
                         return;
                     }
-                    if (TEXT_OFFER_X.equals(PriceUtils.sanitizeWidgetText(entry.getOption())) && entry.getIdentifier() == 5)
+                    if (option.equals(TEXT_OFFER_X) && entry.getIdentifier() == 5)
                     {
                         final int offerItemID = PriceUtils.getItemIdFromWidget(w);
                         if (offerItemID == -1)
@@ -233,34 +237,55 @@ public class OfferManager
                         priceKeyListener.setSelectedItemID(offerItemID);
                         entry.setOption(TEXT_OFFER_PRICE_X);
                         entry.onClick(e -> {
-                            priceKeyListener.setActive(true);
+                            priceKeyListener.setTransferState(PriceKeyListener.TransferState.GIVING);
                             Objects.requireNonNull(client.getWidget(WIDGET_ID_TEXT_ENTRY, WIDGET_CHILD_ID_TEXT_ENTRY)).setText(TEXT_INITIAL_PROMPT_FOR_PRICE);
                         });
                     }
                     break;
+                }
                 case InterfaceID.TRADEMAIN:
+                {
                     int id = w.getItemId();
-                    if (!Text.removeTags(entry.getOption()).trim().equals(OPTION_EXAMINE))
+                    if (option.equals(OPTION_EXAMINE))
                     {
-                        break;
-                    }
-                    if (id != -1)
-                    {
-                        client.getMenu().createMenuEntry(idx)
-                                .setType(MenuAction.RUNELITE)
-                                .setOption(OPTION_SET_PRICE)
-                                .setTarget("")
-                                .onClick(menuEntry -> {
-                                    PriceUtils.promptString(TEXT_INITIAL_PROMPT_FOR_PRICE, "", input -> {
-                                        if (PriceUtils.isValidPrice(input))
-                                        {
-                                            setInputPrice(Integer.parseInt(PriceUtils.transformDecimalPrice(input)));
-                                            clientThread.invokeLater(this::updateTradeData);
-                                        }
+                        if (w.getItemId() != -1)
+                        {
+                            client.getMenu().createMenuEntry(idx)
+                                    .setType(MenuAction.RUNELITE)
+                                    .setOption(OPTION_SET_PRICE)
+                                    .setTarget("")
+                                    .onClick(menuEntry -> {
+                                        PriceUtils.promptString(TEXT_INITIAL_PROMPT_FOR_PRICE, "", input -> {
+                                            if (PriceUtils.isValidPrice(input))
+                                            {
+                                                setInputPrice(Integer.parseInt(PriceUtils.transformDecimalPrice(input)));
+                                                clientThread.invokeLater(this::updateTradeData);
+                                            }
+                                        });
                                     });
-                                });
+                        }
+                    }
+                    else if (option.equals(TEXT_REMOVE_X))
+                    {
+                        final int offerItemID = PriceUtils.getItemIdFromWidget(w);
+                        if (offerItemID == -1)
+                        {
+                            return;
+                        }
+                        final TradeType offerType = PriceUtils.getOfferType(offerItemID, config.showReasonIfInvalid());
+                        if (offerType == TradeType.INVALID)
+                        {
+                            return;
+                        }
+                        priceKeyListener.setSelectedItemID(offerItemID);
+                        entry.setOption(TEXT_REMOVE_PRICE_X);
+                        entry.onClick(e -> {
+                            priceKeyListener.setTransferState(PriceKeyListener.TransferState.REMOVING);
+                            Objects.requireNonNull(client.getWidget(WIDGET_ID_TEXT_ENTRY, WIDGET_CHILD_ID_TEXT_ENTRY)).setText(TEXT_INITIAL_PROMPT_FOR_PRICE);
+                        });
                     }
                     break;
+                }
             }
         }
     }

--- a/src/main/java/org/asundr/OfferManager.java
+++ b/src/main/java/org/asundr/OfferManager.java
@@ -267,6 +267,10 @@ public class OfferManager
                     }
                     else if (option.equals(TEXT_REMOVE_X))
                     {
+                        if (!client.isKeyPressed(KeyCode.KC_SHIFT))
+                        {
+                            return;
+                        }
                         final int offerItemID = PriceUtils.getItemIdFromWidget(w);
                         if (offerItemID == -1)
                         {

--- a/src/main/java/org/asundr/PriceKeyListener.java
+++ b/src/main/java/org/asundr/PriceKeyListener.java
@@ -25,7 +25,6 @@
 
 package org.asundr;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.*;
@@ -43,13 +42,17 @@ import java.util.Objects;
 
 public class PriceKeyListener implements KeyListener
 {
-    //private static int VARCLIENTSTR_INPUT_TEXT = 359; //VarClientStr.INPUT_TEXT
+    enum TransferState { INACTIVE, GIVING, REMOVING; }
 
-    private static final String TEMPLATE_PRICE_PROMPT = "Enter a price: (will give %s)";
+    private static final String TEMPLATE_PRICE_PROMPT = "Enter a price: (will %s %s)";
+    private static final String TEMPLATE_PRICE_PROMPT_GIVING = String.format(TEMPLATE_PRICE_PROMPT, "give", "%s");
+    private static final String TEMPLATE_PRICE_PROMPT_REMOVING = String.format(TEMPLATE_PRICE_PROMPT, "remove", "%s");
     private static final String MESSAGE_PREFIX = "[Offer at Price] ";
     private static final String TEMPLATE_REMOVE_ITEMS = MESSAGE_PREFIX + "You need to remove %s item(s) from your current offer to match %s item(s) at the provided price (%s).";
+    private static final String TEMPLATE_ADD_ITEMS = MESSAGE_PREFIX + "You need to add %s item(s) to your current offer to match %s item(s) at the provided price (%s).";
     private static final String TEMPLATE_NOT_ENOUGH_ITEMS = MESSAGE_PREFIX + "You don't have enough items (missing %s) to match at the provided price (%s). Value of your offer: %s.";
     private static final String TEMPLATE_REMOVE_COINS = MESSAGE_PREFIX + "You need to remove %sgp from your current offer to match %sgp worth of items at the provided price (%sgp).";
+    private static final String TEMPLATE_ADD_COINS = MESSAGE_PREFIX + "You need to add %sgp to your current offer to match %sgp at the provided price (%sgp).";
     private static final String TEMPLATE_NOT_ENOUGH_COINS = MESSAGE_PREFIX + "You don't have enough coins (missing %sgp) to match at the provided price (%sgp). Can afford %s item(s) at this price.";
 
     private final Client client;
@@ -66,8 +69,20 @@ public class PriceKeyListener implements KeyListener
     private TradeType selectedItemTradeType = TradeType.INVALID;
     private String lastInputText;
 
-    @Setter(AccessLevel.PACKAGE)
-    private boolean active = false;
+    private TransferState transferState = TransferState.INACTIVE;
+
+
+    // Enables and determines how to interpret quantity data
+    void setTransferState(TransferState state)
+    {
+        if (transferState == state)
+        {
+            return;
+        }
+        transferState = state;
+    }
+
+    private boolean isActive() { return transferState != TransferState.INACTIVE; }
 
 
     public PriceKeyListener(final Client client, final ClientThread clientThread, final OfferAtPriceConfig config)
@@ -80,7 +95,7 @@ public class PriceKeyListener implements KeyListener
     @Subscribe
     private void onClientTick(ClientTick event)
     {
-        if (!active)
+        if (!isActive())
         {
             return;
         }
@@ -88,14 +103,15 @@ public class PriceKeyListener implements KeyListener
         final Widget promptWidget = client.getWidget(OfferManager.WIDGET_ID_TEXT_ENTRY, OfferManager.WIDGET_CHILD_ID_TEXT_ENTRY);
         if (promptWidget != null)
         {
-            promptWidget.setText(String.format(TEMPLATE_PRICE_PROMPT, getOutputQuantity()));
+            final String prompt = transferState == TransferState.GIVING ? TEMPLATE_PRICE_PROMPT_GIVING : TEMPLATE_PRICE_PROMPT_REMOVING;
+            promptWidget.setText(String.format(prompt, getOutputQuantity()));
         }
     }
 
     @Override
     public void keyPressed(KeyEvent e)
     {
-        if (!active)
+        if (!isActive())
         {
             return;
         }
@@ -106,8 +122,9 @@ public class PriceKeyListener implements KeyListener
         }
         else
         {
+            final String prompt = transferState == TransferState.GIVING ? TEMPLATE_PRICE_PROMPT_GIVING : TEMPLATE_PRICE_PROMPT_REMOVING;
             Objects.requireNonNull(client.getWidget(OfferManager.WIDGET_ID_TEXT_ENTRY, OfferManager.WIDGET_CHILD_ID_TEXT_ENTRY))
-                    .setText(String.format(TEMPLATE_PRICE_PROMPT, "..."));
+                    .setText(String.format(prompt, "..."));
         }
     }
 
@@ -146,59 +163,86 @@ public class PriceKeyListener implements KeyListener
             {
                 final long receivedCurrency = PriceUtils.getTotalCurrencyValue(PriceUtils.TRADEOTHER);
                 final long alreadyOfferedItems = PriceUtils.getQuantity(InventoryID.TRADEOFFER, selectedItemID);
-                final long sellCount = config.defaultRoundingMethod().method.apply((double)receivedCurrency / (double)inputPricePerItem) - alreadyOfferedItems;
+                final long expectedItemCount = config.defaultRoundingMethod().method.apply((double)receivedCurrency / (double)inputPricePerItem);
+                final long transferCount = expectedItemCount - alreadyOfferedItems;
                 final long inventoryQuantity = PriceUtils.getQuantity(InventoryID.INV, selectedItemID);
                 if (printWarning)
                 {
-                    if (sellCount < 0)
+                    if (transferState == TransferState.GIVING)
                     {
-                        final long expectedItemCount = config.defaultRoundingMethod().method.apply((double)receivedCurrency / (double)inputPricePerItem);
-                        PriceUtils.chatMessage(config.notifyNeedToRemove(),
-                                String.format(TEMPLATE_REMOVE_ITEMS,
-                                        QuantityFormatter.formatNumber(-sellCount),
-                                        QuantityFormatter.formatNumber(expectedItemCount),
-                                        QuantityFormatter.formatNumber(inputPricePerItem)));
+                        if (transferCount < 0)
+                        {
+                            PriceUtils.chatMessage(config.notifyNeedToRemove(),
+                                    String.format(TEMPLATE_REMOVE_ITEMS,
+                                            QuantityFormatter.formatNumber(-transferCount),
+                                            QuantityFormatter.formatNumber(expectedItemCount),
+                                            QuantityFormatter.formatNumber(inputPricePerItem)));
+                        }
+                        else if (inventoryQuantity < transferCount)
+                        {
+                            final long valueOfYourOffer = inputPricePerItem * (alreadyOfferedItems + inventoryQuantity);
+                            PriceUtils.chatMessage(config.notifyNotEnough(),
+                                    String.format(TEMPLATE_NOT_ENOUGH_ITEMS,
+                                            QuantityFormatter.formatNumber(transferCount - inventoryQuantity),
+                                            QuantityFormatter.formatNumber(inputPricePerItem),
+                                            QuantityFormatter.formatNumber(valueOfYourOffer)));
+                        }
                     }
-                    else if (inventoryQuantity < sellCount)
+                    else  // Removing
                     {
-                        final long valueOfYourOffer = inputPricePerItem * (alreadyOfferedItems + inventoryQuantity);
-                        PriceUtils.chatMessage(config.notifyNotEnough(),
-                                String.format(TEMPLATE_NOT_ENOUGH_ITEMS,
-                                        QuantityFormatter.formatNumber(sellCount - inventoryQuantity),
-                                        QuantityFormatter.formatNumber(inputPricePerItem),
-                                        QuantityFormatter.formatNumber(valueOfYourOffer)));
+                        if (transferCount > 0)
+                        {
+                            PriceUtils.chatMessage(config.notifyNeedToAdd(),
+                                    String.format(TEMPLATE_ADD_ITEMS,
+                                    QuantityFormatter.formatNumber(expectedItemCount - alreadyOfferedItems),
+                                    QuantityFormatter.formatNumber(expectedItemCount),
+                                    QuantityFormatter.formatNumber(inputPricePerItem)));                        }
                     }
                 }
-                outNum = Math.max(0, Math.min(Integer.MAX_VALUE, sellCount));
+                outNum = Math.max(0, Math.min(Integer.MAX_VALUE, transferState == TransferState.GIVING ? transferCount : -transferCount));
             }
         }
         else // BUY (giving currency for items)
         {
             final long receivedQuantity = PriceUtils.getQuantity(PriceUtils.TRADEOTHER, PriceUtils.getFirstItem(PriceUtils.TRADEOTHER));
             final long alreadyOfferedCurrency = PriceUtils.getTotalCurrencyValue(InventoryID.TRADEOFFER);
-            final long offerQuantity = inputPricePerItem * receivedQuantity - alreadyOfferedCurrency;
+            final long transferQuantity = inputPricePerItem * receivedQuantity - alreadyOfferedCurrency;
             final long inventoryCurrency = PriceUtils.getTotalCurrencyValue(InventoryID.INV);
             if (printWarning)
             {
-                if (offerQuantity < 0)
+                if (transferState == TransferState.GIVING)
                 {
-                    PriceUtils.chatMessage(config.notifyNeedToRemove(),
-                            String.format(TEMPLATE_REMOVE_COINS,
-                                    QuantityFormatter.formatNumber(-offerQuantity),
-                                    QuantityFormatter.formatNumber(inputPricePerItem * receivedQuantity),
-                                    QuantityFormatter.formatNumber(inputPricePerItem)));
+                    if (transferQuantity < 0)
+                    {
+                        PriceUtils.chatMessage(config.notifyNeedToRemove(),
+                                String.format(TEMPLATE_REMOVE_COINS,
+                                        QuantityFormatter.formatNumber(-transferQuantity),
+                                        QuantityFormatter.formatNumber(inputPricePerItem * receivedQuantity),
+                                        QuantityFormatter.formatNumber(inputPricePerItem)));
+                    }
+                    else if (inventoryCurrency < transferQuantity)
+                    {
+                        final long canAffordCount = (alreadyOfferedCurrency + inventoryCurrency) / (long)inputPricePerItem;
+                        PriceUtils.chatMessage(config.notifyNotEnough(),
+                                String.format(TEMPLATE_NOT_ENOUGH_COINS,
+                                        QuantityFormatter.formatNumber(transferQuantity - inventoryCurrency),
+                                        QuantityFormatter.formatNumber(inputPricePerItem),
+                                        QuantityFormatter.formatNumber(canAffordCount)));
+                    }
                 }
-                else if (inventoryCurrency < offerQuantity)
+                else
                 {
-                    final long canAffordCount = (alreadyOfferedCurrency + inventoryCurrency) / (long)inputPricePerItem;
-                    PriceUtils.chatMessage(config.notifyNotEnough(),
-                            String.format(TEMPLATE_NOT_ENOUGH_COINS,
-                                    QuantityFormatter.formatNumber(offerQuantity - inventoryCurrency),
-                                    QuantityFormatter.formatNumber(inputPricePerItem),
-                                    QuantityFormatter.formatNumber(canAffordCount)));
+                    if (transferQuantity > 0)
+                    {
+                        PriceUtils.chatMessage(config.notifyNeedToAdd(),
+                                String.format(TEMPLATE_ADD_COINS,
+                                        QuantityFormatter.formatNumber(transferQuantity),
+                                        QuantityFormatter.formatNumber(inputPricePerItem * receivedQuantity),
+                                        QuantityFormatter.formatNumber(inputPricePerItem)));
+                    }
                 }
             }
-            outNum = Math.max(0, Math.min(offerQuantity, Integer.MAX_VALUE));
+            outNum = Math.max(0, Math.min(Integer.MAX_VALUE, transferState == TransferState.GIVING ? transferQuantity : -transferQuantity));
         }
         return outNum;
     }

--- a/src/main/java/org/asundr/PriceKeyListener.java
+++ b/src/main/java/org/asundr/PriceKeyListener.java
@@ -49,7 +49,7 @@ public class PriceKeyListener implements KeyListener
     private static final String TEMPLATE_PRICE_PROMPT_REMOVING = String.format(TEMPLATE_PRICE_PROMPT, "remove", "%s");
     private static final String MESSAGE_PREFIX = "[Offer at Price] ";
     private static final String TEMPLATE_REMOVE_ITEMS = MESSAGE_PREFIX + "You need to remove %s item(s) from your current offer to match %s item(s) at the provided price (%s).";
-    private static final String TEMPLATE_ADD_ITEMS = MESSAGE_PREFIX + "You need to add %s item(s) to your current offer to match %s item(s) at the provided price (%s).";
+    private static final String TEMPLATE_ADD_ITEMS = MESSAGE_PREFIX + "You need to add %s item(s) to your current offer to match %s items at the provided price (%s).";
     private static final String TEMPLATE_NOT_ENOUGH_ITEMS = MESSAGE_PREFIX + "You don't have enough items (missing %s) to match at the provided price (%s). Value of your offer: %s.";
     private static final String TEMPLATE_REMOVE_COINS = MESSAGE_PREFIX + "You need to remove %sgp from your current offer to match %sgp worth of items at the provided price (%sgp).";
     private static final String TEMPLATE_ADD_COINS = MESSAGE_PREFIX + "You need to add %sgp to your current offer to match %sgp at the provided price (%sgp).";
@@ -165,39 +165,9 @@ public class PriceKeyListener implements KeyListener
                 final long alreadyOfferedItems = PriceUtils.getQuantity(InventoryID.TRADEOFFER, selectedItemID);
                 final long expectedItemCount = config.defaultRoundingMethod().method.apply((double)receivedCurrency / (double)inputPricePerItem);
                 final long transferCount = expectedItemCount - alreadyOfferedItems;
-                final long inventoryQuantity = PriceUtils.getQuantity(InventoryID.INV, selectedItemID);
                 if (printWarning)
                 {
-                    if (transferState == TransferState.GIVING)
-                    {
-                        if (transferCount < 0)
-                        {
-                            PriceUtils.chatMessage(config.notifyNeedToRemove(),
-                                    String.format(TEMPLATE_REMOVE_ITEMS,
-                                            QuantityFormatter.formatNumber(-transferCount),
-                                            QuantityFormatter.formatNumber(expectedItemCount),
-                                            QuantityFormatter.formatNumber(inputPricePerItem)));
-                        }
-                        else if (inventoryQuantity < transferCount)
-                        {
-                            final long valueOfYourOffer = inputPricePerItem * (alreadyOfferedItems + inventoryQuantity);
-                            PriceUtils.chatMessage(config.notifyNotEnough(),
-                                    String.format(TEMPLATE_NOT_ENOUGH_ITEMS,
-                                            QuantityFormatter.formatNumber(transferCount - inventoryQuantity),
-                                            QuantityFormatter.formatNumber(inputPricePerItem),
-                                            QuantityFormatter.formatNumber(valueOfYourOffer)));
-                        }
-                    }
-                    else  // Removing
-                    {
-                        if (transferCount > 0)
-                        {
-                            PriceUtils.chatMessage(config.notifyNeedToAdd(),
-                                    String.format(TEMPLATE_ADD_ITEMS,
-                                    QuantityFormatter.formatNumber(expectedItemCount - alreadyOfferedItems),
-                                    QuantityFormatter.formatNumber(expectedItemCount),
-                                    QuantityFormatter.formatNumber(inputPricePerItem)));                        }
-                    }
+                    printSellingWarning(inputPricePerItem, alreadyOfferedItems, expectedItemCount, transferCount);
                 }
                 outNum = Math.max(0, Math.min(Integer.MAX_VALUE, transferState == TransferState.GIVING ? transferCount : -transferCount));
             }
@@ -207,46 +177,86 @@ public class PriceKeyListener implements KeyListener
             final long receivedQuantity = PriceUtils.getQuantity(PriceUtils.TRADEOTHER, PriceUtils.getFirstItem(PriceUtils.TRADEOTHER));
             final long alreadyOfferedCurrency = PriceUtils.getTotalCurrencyValue(InventoryID.TRADEOFFER);
             final long transferQuantity = inputPricePerItem * receivedQuantity - alreadyOfferedCurrency;
-            final long inventoryCurrency = PriceUtils.getTotalCurrencyValue(InventoryID.INV);
             if (printWarning)
             {
-                if (transferState == TransferState.GIVING)
-                {
-                    if (transferQuantity < 0)
-                    {
-                        PriceUtils.chatMessage(config.notifyNeedToRemove(),
-                                String.format(TEMPLATE_REMOVE_COINS,
-                                        QuantityFormatter.formatNumber(-transferQuantity),
-                                        QuantityFormatter.formatNumber(inputPricePerItem * receivedQuantity),
-                                        QuantityFormatter.formatNumber(inputPricePerItem)));
-                    }
-                    else if (inventoryCurrency < transferQuantity)
-                    {
-                        final long canAffordCount = (alreadyOfferedCurrency + inventoryCurrency) / (long)inputPricePerItem;
-                        PriceUtils.chatMessage(config.notifyNotEnough(),
-                                String.format(TEMPLATE_NOT_ENOUGH_COINS,
-                                        QuantityFormatter.formatNumber(transferQuantity - inventoryCurrency),
-                                        QuantityFormatter.formatNumber(inputPricePerItem),
-                                        QuantityFormatter.formatNumber(canAffordCount)));
-                    }
-                }
-                else
-                {
-                    if (transferQuantity > 0)
-                    {
-                        PriceUtils.chatMessage(config.notifyNeedToAdd(),
-                                String.format(TEMPLATE_ADD_COINS,
-                                        QuantityFormatter.formatNumber(transferQuantity),
-                                        QuantityFormatter.formatNumber(inputPricePerItem * receivedQuantity),
-                                        QuantityFormatter.formatNumber(inputPricePerItem)));
-                    }
-                }
+                printBuyingWarning(inputPricePerItem, receivedQuantity, alreadyOfferedCurrency, transferQuantity);
             }
             outNum = Math.max(0, Math.min(Integer.MAX_VALUE, transferState == TransferState.GIVING ? transferQuantity : -transferQuantity));
         }
         return outNum;
     }
     private long getOutputQuantity() {return getOutputQuantity(false); }
+
+    private void printSellingWarning(int inputPricePerItem, long alreadyOfferedItems, long expectedItemCount, long transferCount)
+    {
+        final long inventoryQuantity = PriceUtils.getQuantity(InventoryID.INV, selectedItemID);
+        if (transferState == TransferState.GIVING)
+        {
+            if (transferCount < 0)
+            {
+                PriceUtils.chatMessage(config.notifyNeedToRemove(),
+                        String.format(TEMPLATE_REMOVE_ITEMS,
+                                QuantityFormatter.formatNumber(-transferCount),
+                                QuantityFormatter.formatNumber(expectedItemCount),
+                                QuantityFormatter.formatNumber(inputPricePerItem)));
+            }
+            else if (inventoryQuantity < transferCount)
+            {
+                final long valueOfYourOffer = inputPricePerItem * (alreadyOfferedItems + inventoryQuantity);
+                PriceUtils.chatMessage(config.notifyNotEnough(),
+                        String.format(TEMPLATE_NOT_ENOUGH_ITEMS,
+                                QuantityFormatter.formatNumber(transferCount - inventoryQuantity),
+                                QuantityFormatter.formatNumber(inputPricePerItem),
+                                QuantityFormatter.formatNumber(valueOfYourOffer)));
+            }
+        }
+        else  // Removing
+        {
+            if (transferCount > 0)
+            {
+                PriceUtils.chatMessage(config.notifyNeedToAdd(),
+                        String.format(TEMPLATE_ADD_ITEMS,
+                                QuantityFormatter.formatNumber(expectedItemCount - alreadyOfferedItems),
+                                QuantityFormatter.formatNumber(expectedItemCount),
+                                QuantityFormatter.formatNumber(inputPricePerItem)));                        }
+        }
+    }
+
+    private void printBuyingWarning(int inputPricePerItem, long receivedQuantity, long alreadyOfferedCurrency, long transferQuantity)
+    {
+        final long inventoryCurrency = PriceUtils.getTotalCurrencyValue(InventoryID.INV);
+        if (transferState == TransferState.GIVING)
+        {
+            if (transferQuantity < 0)
+            {
+                PriceUtils.chatMessage(config.notifyNeedToRemove(),
+                        String.format(TEMPLATE_REMOVE_COINS,
+                                QuantityFormatter.formatNumber(-transferQuantity),
+                                QuantityFormatter.formatNumber(inputPricePerItem * receivedQuantity),
+                                QuantityFormatter.formatNumber(inputPricePerItem)));
+            }
+            else if (inventoryCurrency < transferQuantity)
+            {
+                final long canAffordCount = (alreadyOfferedCurrency + inventoryCurrency) / (long)inputPricePerItem;
+                PriceUtils.chatMessage(config.notifyNotEnough(),
+                        String.format(TEMPLATE_NOT_ENOUGH_COINS,
+                                QuantityFormatter.formatNumber(transferQuantity - inventoryCurrency),
+                                QuantityFormatter.formatNumber(inputPricePerItem),
+                                QuantityFormatter.formatNumber(canAffordCount)));
+            }
+        }
+        else
+        {
+            if (transferQuantity > 0)
+            {
+                PriceUtils.chatMessage(config.notifyNeedToAdd(),
+                        String.format(TEMPLATE_ADD_COINS,
+                                QuantityFormatter.formatNumber(transferQuantity),
+                                QuantityFormatter.formatNumber(inputPricePerItem * receivedQuantity),
+                                QuantityFormatter.formatNumber(inputPricePerItem)));
+            }
+        }
+    }
 
     @Override public void keyTyped(KeyEvent e) { }
     @Override public void keyReleased(KeyEvent e) { }


### PR DESCRIPTION
closes #8 

* SHIFT Right clicking offered items in the trade menu shows replaces "Remove-X" option with "Remove-Price-X"
* Remove-Price-X removes already offered items / coins to match the opposing office at the given price
* Warning message if trying to remove items when the player has already offered too few